### PR TITLE
Some fixups to work with the build system integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Geoffroy Couprie <geo.couprie@gmail.com>", "Guillaume Gomez <guillau
 build = "build.rs"
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["staticlib"]
 
 [dependencies]
 libc = "0.2.0"


### PR DESCRIPTION
dump the directory as `rust` in `modules/demux` in my vlc rust branch
